### PR TITLE
Add .gitignore for build artifacts and temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build artifacts
+build/
+node_modules/
+package-lock.json
+
+# IDE files
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*


### PR DESCRIPTION
Hi, thanks for this project.  I have made quite a bit of use of it.

Sending you this pull request as a suggestion.  A .gitignore that excludes build artifacts to stop them showing up on git status.  This is useful when adding this as a submodule to another project.

Feel free to incorporate, ask for changes. or scrap it.  All are fine.