### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides GDB debugging functionality for use with Claude or other AI assistants.
 
+<a href="https://glama.ai/mcp/servers/@signal-slot/mcp-gdb">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@signal-slot/mcp-gdb/badge" alt="GDB Server MCP server" />
+</a>
+
 ## Features
 
 - Start and manage GDB debugging sessions


### PR DESCRIPTION
This PR adds a badge for the [MCP GDB Server](https://glama.ai/mcp/servers/@signal-slot/mcp-gdb) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@signal-slot/mcp-gdb">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@signal-slot/mcp-gdb/badge" alt="GDB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.